### PR TITLE
Fix broken service, refactor private networks check and get ip score from virustotal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
  
     <groupId>net.redborder</groupId>
     <artifactId>rb-reputation</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>1.1.5-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/net/redborder/malware/modules/data/MetaScanDataModule.java
+++ b/src/main/java/net/redborder/malware/modules/data/MetaScanDataModule.java
@@ -2,10 +2,8 @@ package net.redborder.malware.modules.data;
 
 import net.redborder.malware.config.Config;
 import net.redborder.malware.config.ConfigException;
-<<<<<<< HEAD
-=======
 import net.redborder.malware.utils.HTTP;
->>>>>>> bugfix/remove_http_or_https_for_metadefender_urls
+import net.redborder.malware.utils.IPUtils;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -83,37 +81,6 @@ public class MetaScanDataModule extends AbstractDataModule {
     }
     
     /**
-     * Check whether input ip is in the range of private networks 
-     * 
-     * <li> Class A: 10.0.0.0 ------- 10.255.255.255 </li>
-     * <li> Class B: 172.16.0.0 ---- 172.31.255.255 </li>
-     * <li> Class C: 192.168.0.0 --- 192.168.255.255 </li>
-     *
-     * @param ip String with the ip to check.
-     * @return true if the ip is private. Otherwise returns false.
-     */
-    private boolean isPrivateNetwork(String ip) {
-    	Integer sub_ip = Integer.valueOf(ip.substring(0, ip.indexOf(".")));
-    	boolean isPrivate = false;
-		switch (sub_ip) {
-			case 10:
-				isPrivate = true;
-				break;
-			case 172:
-				sub_ip = Integer.valueOf(ip.substring(4, ip.indexOf(".",4)));
-				if (sub_ip >= 16 && sub_ip < 32)
-					isPrivate = true;
-				break;
-			case 192:
-				sub_ip = Integer.valueOf(ip.substring(4, ip.indexOf(".",4)));
-				if (sub_ip.equals(168))
-					isPrivate = true;
-				break;	
-		}
-		return isPrivate;
-    }
-    
-    /**
      * Method to get url, ip or hash malware score using Metadefender API. 
      * @param queryObject String with the url, ip or hash to analyze.
      * @param queryParameter String with the type of object. It must be one of the aforementioned objects.  
@@ -124,7 +91,7 @@ public class MetaScanDataModule extends AbstractDataModule {
     	
     	
     	if (queryParameter.equals("IP")){
-    		if (isPrivateNetwork(queryObject)) {
+    		if (IPUtils.isPrivateNetwork(queryObject)) {
     			log.info("Private IP");
     			return 0;
     		}
@@ -220,19 +187,11 @@ public class MetaScanDataModule extends AbstractDataModule {
 
     @Override
     public Map<String, Object> processQueryURL(String URL) {
-<<<<<<< HEAD
 
         int score;
         
 		score = getScore(URL, "URL", lookupURL);
 
-=======
-
-        int score;
-        
-		score = getScore(URL, "URL", lookupURL);
-
->>>>>>> bugfix/remove_http_or_https_for_metadefender_urls
         Map<String, Object> finalResult = new HashMap<>();
         finalResult.put("url", URL);
 

--- a/src/main/java/net/redborder/malware/modules/data/OTXDataModule.java
+++ b/src/main/java/net/redborder/malware/modules/data/OTXDataModule.java
@@ -1,5 +1,6 @@
 package net.redborder.malware.modules.data;
 
+import net.redborder.malware.utils.IPUtils;
 import org.json.JSONObject;
 import net.redborder.malware.config.Config;
 import org.slf4j.Logger;
@@ -21,37 +22,6 @@ public class OTXDataModule extends AbstractDataModule {
         super(conf);
 
     }
-	
-	/**
-     * Check whether input ip is in the range of private networks 
-     * 
-     * <li> Class A: 10.0.0.0 ------- 10.255.255.255 </li>
-     * <li> Class B: 172.16.0.0 ---- 172.31.255.255 </li>
-     * <li> Class C: 192.168.0.0 --- 192.168.255.255 </li>
-     *
-     * @param ip String with the ip to check.
-     * @return true if the ip is private. Otherwise returns false.
-     */
-    private static boolean isPrivateNetwork(String ip) {
-    	Integer sub_ip = Integer.valueOf(ip.substring(0, ip.indexOf(".")));
-    	boolean isPrivate = false;
-		switch (sub_ip) {
-			case 10:
-				isPrivate = true;
-				break;
-			case 172:
-				sub_ip = Integer.valueOf(ip.substring(4, ip.indexOf(".",4)));
-				if (sub_ip >= 16 && sub_ip < 32)
-					isPrivate = true;
-				break;
-			case 192:
-				sub_ip = Integer.valueOf(ip.substring(4, ip.indexOf(".",4)));
-				if (sub_ip.equals(168))
-					isPrivate = true;
-				break;	
-		}
-		return isPrivate;
-    }
 
 	/**
 	 * getPulses(String ip) method returns an integer with the number of "pulses" in AlienVault. 
@@ -62,7 +32,7 @@ public class OTXDataModule extends AbstractDataModule {
 	 */
 	public static int getPulses(String ip) {
 		
-		if (isPrivateNetwork(ip)) {
+		if (IPUtils.isPrivateNetwork(ip)) {
 			log.info("Private IP");
 			return 0;
 		}

--- a/src/main/java/net/redborder/malware/modules/data/VirusTotalDataModule.java
+++ b/src/main/java/net/redborder/malware/modules/data/VirusTotalDataModule.java
@@ -1,5 +1,7 @@
 package net.redborder.malware.modules.data;
 
+import net.redborder.malware.utils.IPUtils;
+import com.kanishka.virustotal.dto.URL;
 import com.kanishka.virustotal.dto.FileScanReport;
 import com.kanishka.virustotal.dto.IPAddressReport;
 import com.kanishka.virustotal.exception.APIKeyNotFoundException;
@@ -151,12 +153,25 @@ public class VirusTotalDataModule extends AbstractDataModule {
         Map<String, Object> result = new HashMap<>();
 
         result.put("ip", IP);
-
+        if(IPUtils.isPrivateNetwork(IP)){
+            log.info("Requesting to private IP, returning with code 0");
+            result.put("score", 0);
+            return result;
+        }
         try {
             ipInformation = virusTotalRef.getIPAddresReport(IP);
-            log.trace("Petition for IP completed with code : {}", ipInformation.getResponseCode());
-
-            result.put("score", -1);
+            log.info("Petition for IP completed with code : {}", ipInformation.getResponseCode());
+            if (ipInformation.getResponseCode() != 0){
+                int score = 0;
+                URL[] urls = ipInformation.getDetectedUrls();
+                if(urls.length >= 0){
+                    score = urls[0].getPositives() * 100 / urls[0].getTotal();
+                }
+                log.info("Got IP score from VirusTotal {}", score);
+                result.put("score", score);
+            } else {
+                result.put("score", -1);
+            }
         } catch (InvalidArguentsException e) {
             log.error(e.getLocalizedMessage());
             result.put("score", -1);

--- a/src/main/java/net/redborder/malware/modules/data/VirusTotalDataModule.java
+++ b/src/main/java/net/redborder/malware/modules/data/VirusTotalDataModule.java
@@ -164,7 +164,7 @@ public class VirusTotalDataModule extends AbstractDataModule {
             if (ipInformation.getResponseCode() != 0){
                 int score = 0;
                 URL[] urls = ipInformation.getDetectedUrls();
-                if(urls.length >= 0){
+                if(urls.length > 0){
                     score = urls[0].getPositives() * 100 / urls[0].getTotal();
                 }
                 log.info("Got IP score from VirusTotal {}", score);

--- a/src/main/java/net/redborder/malware/utils/IPUtils.java
+++ b/src/main/java/net/redborder/malware/utils/IPUtils.java
@@ -1,0 +1,35 @@
+package net.redborder.malware.utils;
+
+public class IPUtils {
+    
+    /**
+     * Check whether the input IP is in the range of private networks 
+     * 
+     * <li> Class A: 10.0.0.0 ------- 10.255.255.255 </li>
+     * <li> Class B: 172.16.0.0 ---- 172.31.255.255 </li>
+     * <li> Class C: 192.168.0.0 --- 192.168.255.255 </li>
+     *
+     * @param ip String with the IP to check.
+     * @return true if the IP is private. Otherwise, returns false.
+     */
+    public static boolean isPrivateNetwork(String ip) {
+        Integer sub_ip = Integer.valueOf(ip.substring(0, ip.indexOf(".")));
+        boolean isPrivate = false;
+        switch (sub_ip) {
+            case 10:
+                isPrivate = true;
+                break;
+            case 172:
+                sub_ip = Integer.valueOf(ip.substring(4, ip.indexOf(".", 4)));
+                if (sub_ip >= 16 && sub_ip < 32)
+                    isPrivate = true;
+                break;
+            case 192:
+                sub_ip = Integer.valueOf(ip.substring(4, ip.indexOf(".", 4)));
+                if (sub_ip.equals(168))
+                    isPrivate = true;
+                break;
+        }
+        return isPrivate;
+    }
+}


### PR DESCRIPTION
Title: Bug Fix, Refactoring, and New Feature: VirusTotal IP Score Retrieval

Description:
This pull request brings three important technical updates to enhance the codebase and improve the service:

BugFix: The service experienced a critical issue due to a merge conflict. I have resolved the conflict and fixed the code.

Code Refactoring: isPrivateNetwork Check
As part of code maintenance, I refactored the `isPrivateNetwork` check. By removing redundant methods in `MetaScanDataModule.java` and `OTXDataModule.java`, I introduced a shared utility function, `IPUtils.isPrivateNetwork`, located in `src/main/java/net/redborder/malware/utils/IPUtils.java`. This refactoring ensures consistent handling of private IPs throughout the codebase, reducing the chances of errors and making future updates more manageable.

New Feature: VirusTotal IP Score Retrieval
New feature that allows fetching scores from IPs using VirusTotal. When processing IP-related data in `MetaScanDataModule.java`, `OTXDataModule.java` and `VirusTotalDataModule.java`, I use the `IPUtils.isPrivateNetwork` function to avoid making score requests for private IPs, optimizing performance. Additionally, in `VirusTotalDataModule.java`, I have implemented a function to retrieve scores for IPs from VirusTotal. The `IPUtils.isPrivateNetwork` function is leveraged to prevent unnecessary API calls for private IPs, further enhancing the efficiency of our service.





